### PR TITLE
refactor: Standardize API routing by configuring Vite proxy for `/v1`…

### DIFF
--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -1,0 +1,66 @@
+# LinkManager Handover Document
+
+This document serves as a comprehensive handover of all architectural changes, bug fixes, and configuration updates performed on the **Eksses LinkManager** repository during this development session.
+
+## 🏗️ Architectural & Configuration Changes
+
+### 1. Unified Local Development (Vite Proxy)
+
+The frontend and backend were previously disjointed, leading to CORS issues and hardcoded port bindings.
+
+- **Vite Proxy Built:** Configured `client/vite.config.js` to proxy all `/api` and `/v1` traffic directly to the unified backend running on port `6997`.
+- **Environment Variables:** Corrected `.env` pathing. Both the `server` (via `dotenv` path config) and `client` (via Vite `envDir`) now correctly load their configurations from the root directory's `.env` file instead of looking in their respective subfolders.
+
+### 2. Vercel Deprecation
+
+The user requested the removal of Vercel-specific deployment constraints to prepare for standard self-hosting/monolith deployment.
+
+- **Removed Files:** Deleted `vercel.json` and `middleware.js` from the root directory.
+- **Backend Cleaned:** Removed Vercel-specific Express configurations like `app.set('trust proxy', 1)` from `server/index.js` and bypassed the Vercel-only backup disable logic in the `BackupService`.
+
+### 3. Default Credentials
+
+- Updated the fallback fallback administrator credentials in `server/routes/auth.js` and `.env.example` from `admin:samir` to the standard `admin:admin` to ensure smooth local onboarding.
+
+## 🐛 Bug Fixes & Code Standardization
+
+### 1. Hardcoded Localhost Removal
+
+Multiple components across the application were hardcoding `http://localhost:5000`, causing `ERR_CONNECTION_REFUSED` since the backend was running on port 6997 and proxying dynamically.
+
+- **Refactored `client/src/api.js`**: Set `baseURL` definitively to `/api`.
+- **`Dashboard.jsx`**: Replaced raw `axios.get('http://localhost:5000...')` with the centralized `api` wrapper, resolving silent data loss and `"No routes matched location /undefined"` React Router crashes.
+- **`ProjectCreate.jsx`**: Replaced a raw POST to port 5000 with the `api.post` interceptor.
+- **`ApiPlayground.jsx`**: Transitioned target URLs from absolute `http://localhost:5000` to relative paths spanning both the `/api` internal structure and the public `/v1` endpoints.
+
+### 2. Duplicate API Path Routing (404s)
+
+- **`LicensesTab.jsx` Fix**: Removed redundant static `/api` prefixes in fetch strings (e.g., changing `/api/licenses` to `/licenses`). Because the `api.js` interceptor inherently injects `/api`, the previous implementation resulted in duplicate `api/api/licenses/` 404 routes.
+- **`/v1` Playground Traffic**: Reactivated native `axios` strictly within `ApiPlayground.jsx` for executing public `/v1` queries. This bypasses the default `/api` interceptor, preventing malformed paths like `/api/v1/heartbeat`.
+
+### 3. Mongoose Deprecation Warnings
+
+The Node backend console was spamming deprecation warnings regarding the usage of `{ new: true }` in `findOneAndUpdate` operations.
+
+- Modernized all four data models across `BackupService.js`, `configs.js`, `client.js`, and `tracker.js` by standardizing the option object to strictly use `{ returnDocument: 'after' }`.
+
+## 📦 Source Control & Contributions
+
+- **Repository Forked**: Created a local fork (`Carloplayz/linkmanager`) due to restricted remote write access.
+- **Branch Created**: All code changes generated in this session were isolated to the `fix/api-networking` branch.
+- **Pull Request Submitted**: Successfully drafted and dispatched **Pull Request #1** to the upstream `R-Samir-Bhuiyan-A/linkmanager` repository containing all proxy and deprecation fixes for the real owner to review and merge into the principal codebase.
+
+## ⚠️ Known Bugs & Non-Issues
+
+The following console messages were observed during development but determined to be harmless or external to the LinkManager codebase:
+
+1. **Bootstrap Autofill Overlay (`Uncaught TypeError: Failed to construct 'URL'`)**
+   - **Diagnosis**: This error originates entirely from a third-party browser extension (specifically related to password/autofill overlays injecting iframes into the React DOM) and does not indicate failing React logic.
+2. **Transient 500 Route Errors on Save**
+   - **Diagnosis**: Nodemon restarts the backend server immediately upon saving a file. If the frontend performs a hot-reload fetch a millisecond before the backend fully boots, an `ECONNREFUSED` or `socket hang up` occurs, resulting in a temporary `500 Internal Server Error`. This resolves inherently upon manual refresh or the subsequent automatic poll.
+3. **React DevTools Notification**
+   - **Diagnosis**: Standard development environment suggestion logged by `react-dom`; safely ignorable.
+
+---
+
+_Created automatically via development session handover._

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -20,7 +20,7 @@ The user requested the removal of Vercel-specific deployment constraints to prep
 
 ### 3. Default Credentials
 
-- Updated the fallback fallback administrator credentials in `server/routes/auth.js` and `.env.example` from `admin:samir` to the standard `admin:admin` to ensure smooth local onboarding.
+- Updated the fallback administrator credentials in `server/routes/auth.js` and `.env.example` from `admin:samir` to the standard `admin:admin` to ensure smooth local onboarding.
 
 ## 🐛 Bug Fixes & Code Standardization
 

--- a/client/src/components/project/LicensesTab.jsx
+++ b/client/src/components/project/LicensesTab.jsx
@@ -21,7 +21,7 @@ export default function LicensesTab({ project }) {
 
     const fetchLicenses = async () => {
         try {
-            const res = await api.get(`/api/licenses/project/${project._id}`);
+            const res = await api.get(`/licenses/project/${project._id}`);
             setLicenses(res.data);
         } catch (err) {
             console.error(err);
@@ -36,7 +36,7 @@ export default function LicensesTab({ project }) {
                 ? new Date(Date.now() + expiryDays * 24 * 60 * 60 * 1000)
                 : null;
 
-            await api.post('/api/licenses/generate', {
+            await api.post('/licenses/generate', {
                 projectId: project._id,
                 holderName,
                 email,
@@ -56,7 +56,7 @@ export default function LicensesTab({ project }) {
     const handleRevoke = async (id) => {
         if (!confirm('Are you sure you want to revoke this license? It cannot be reactivated.')) return;
         try {
-            await api.patch(`/api/licenses/${id}/revoke`);
+            await api.patch(`/licenses/${id}/revoke`);
             success('License revoked');
             fetchLicenses();
         } catch (err) {
@@ -67,7 +67,7 @@ export default function LicensesTab({ project }) {
     const handleResetHwid = async (id) => {
         if (!confirm('Reset Hardware ID lock? The next device to use this key will become the new locked device.')) return;
         try {
-            await api.patch(`/api/licenses/${id}/reset-hwid`);
+            await api.patch(`/licenses/${id}/reset-hwid`);
             success('Hardware ID reset');
             fetchLicenses();
         } catch (err) {

--- a/client/src/pages/ApiPlayground.jsx
+++ b/client/src/pages/ApiPlayground.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import api from '../api';
+import axios from 'axios';
 import { Play, Copy, Check, ChevronRight, Server, Database, Code, FileJson, Layers } from 'lucide-react';
 import PageTransition from '../components/PageTransition';
 
@@ -115,9 +116,9 @@ export default function ApiPlayground() {
             }
 
             if (selectedEndpoint.method === 'GET') {
-                res = await api.get(url, config);
+                res = await axios.get(url, config);
             } else {
-                res = await api.post(url, JSON.parse(body), config);
+                res = await axios.post(url, JSON.parse(body), config);
             }
 
             setResponse({

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -11,6 +11,10 @@ export default defineConfig({
       '/api': {
         target: 'http://localhost:6997',
         changeOrigin: true
+      },
+      '/v1': {
+        target: 'http://localhost:6997',
+        changeOrigin: true
       }
     }
   }


### PR DESCRIPTION
…, removing redundant `/api` prefixes, and documenting changes in `HANDOVER.md`.

## Summary by Sourcery

Standardize frontend API routing by aligning client calls with the Vite proxy configuration and documenting the resulting architecture and behavior.

Enhancements:
- Update license management API calls to rely on the shared API client base path instead of hardcoded `/api` prefixes.
- Adjust the API playground to bypass the internal API wrapper so it can correctly call both internal `/api` and public `/v1` endpoints.
- Extend the Vite dev server proxy to forward `/v1` requests to the backend for unified local development.

Documentation:
- Add a handover document describing the architectural, configuration, and routing changes introduced during this development session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated license management functionality for improved API reliability and consistency.
  * Resolved local development environment configuration issues.

* **Chores**
  * Enhanced development server configuration and tooling infrastructure.
  * Improved internal documentation and standardized development workflows.
  * Removed legacy references for cleaner codebase maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->